### PR TITLE
Fix thread comparator to use proper Long comparison

### DIFF
--- a/jruby-ext/src/main/java/com/purbon/jrmonitor/monitors/HotThreadsMonitor.java
+++ b/jruby-ext/src/main/java/com/purbon/jrmonitor/monitors/HotThreadsMonitor.java
@@ -158,11 +158,11 @@ public class HotThreadsMonitor {
         Collections.sort(reports, new Comparator<ThreadReport>() {
             public int compare(ThreadReport a, ThreadReport b) {
                if ("block".equals(type)) {
-                   return (int) (b.getBlockedTime()-a.getBlockedTime());
+                   return Long.compare(b.getBlockedTime(), a.getBlockedTime());
                } else if ("wait".equals(type)) {
-                   return (int) (b.getWaitedTime()-a.getWaitedTime());
+                   return Long.compare(b.getWaitedTime(), a.getWaitedTime());
                } else {
-                   return (int) (b.getCpuTime()-a.getCpuTime());
+                   return Long.compare(b.getCpuTime(), a.getCpuTime());
                }
             }
         });


### PR DESCRIPTION
I saw a bug in a test run that I can't reproduce similar to http://stackoverflow.com/questions/8327514/comparison-method-violates-its-general-contract

My theory is that somehow maybe the Long values got out of whack. Either way, we shouldn't be casting longs to ints unless we have a high degree of certainty as to their contents (and either way that's just confusing on review).
