### PR TITLE
Bump to 0.4.2 to fix botched 0.4.1 publish

### DIFF
--- a/jrmonitor.gemspec
+++ b/jrmonitor.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "jrmonitor"
-  spec.version       = "0.4.1"
+  spec.version       = "0.4.2"
   spec.authors       = ["Elastic"]
   spec.email         = ["info@elastic.co"]
 


### PR DESCRIPTION
The 0.4.1 publish accidentally released something that was not 0.4.1. This fixes that.
