### PR TITLE
Refactor of the Process Monitor code to be more resilient to errors

### DIFF
--- a/jrmonitor.gemspec
+++ b/jrmonitor.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "jrmonitor"
-  spec.version       = "0.4.2"
+  spec.version       = "0.4.3"
   spec.authors       = ["Elastic"]
   spec.email         = ["info@elastic.co"]
 


### PR DESCRIPTION
In elastic/logstash#6296 we have discovered
that if the user unmount the `/dev/procfs` file the metric collection
would make logstash completely crash.

The solution is to make sure that any calls to beans are wrapped into
try/catch.

This PR do a bit of refactor to implement that behavior.